### PR TITLE
fix: correct stale script references and inconsistent output format

### DIFF
--- a/raggis/sha_compare.rb
+++ b/raggis/sha_compare.rb
@@ -8,6 +8,6 @@ db_sums = Hash[db_list.map! { |sum, n| n ? [File.basename(n), sum] : nil }.compa
 
 cf_sums.each do |name, sum|
   db_sum = db_sums[name]
-  next puts "Missing : #{name}" unless db_sum
+  next puts "Missing: #{name}" unless db_sum
   puts "Mismatch: #{name}" unless db_sum == sum
 end

--- a/redis_sha_import.rb
+++ b/redis_sha_import.rb
@@ -2,7 +2,7 @@
 # Expects files in the format of "SHA  name.gem", uses File.basename on the
 # name, path is irrelevant.
 #
-#   ruby shas_to_redis_sadd.rb rubygems-sha512.name.txt > redis.name.txt
+#   ruby redis_sha_import.rb rubygems-sha512.name.txt > redis.name.txt
 #   redis-cli --pipe < redis.name.txt
 
 # Modified from http://redis.io/topics/mass-insert

--- a/redis_verify.rb
+++ b/redis_verify.rb
@@ -57,7 +57,7 @@ imports = Dir['rubygems-sha512.*'].map do |file|
 
     Process.waitpid convert_pid
 
-    raise 'shas_to_redis_sadd.rb failed' unless $?.success?
+    raise 'redis_sha_import.rb failed' unless $?.success?
 
     Process.waitpid import_pid
 


### PR DESCRIPTION
## Summary

Fix 3 issues across 3 files:

- `redis_verify.rb`: error message references `shas_to_redis_sadd.rb` but the script being spawned is `redis_sha_import.rb` — corrected
- `redis_sha_import.rb`: usage comment references old script name `shas_to_redis_sadd.rb` — updated to match actual filename `redis_sha_import.rb`
- `raggis/sha_compare.rb`: inconsistent output format — `"Missing : "` (extra space before colon) vs `"Mismatch: "` — normalized to `"Missing: "`

**Note:** The `sha_compare.rb` fix changes runtime output format (removes a stray space before the colon in "Missing" lines to match the "Mismatch" format).