### PR TITLE
Add historical archive notice to README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,5 +1,14 @@
 = RubyGems Verification
 
+*Historical archive.* This repository holds the checksum lists, throwaway
+comparison scripts, and gem status lists produced during the response to the
+January 2013 rubygems.org compromise. Its contents have been frozen since that
+time and are kept only as a historical record. It is not used for verifying
+gems today: current checksum verification is handled by RubyGems and Bundler
+themselves (the lockfile CHECKSUMS section, per-version SHA256 in the compact
+index, and checksum verification at gem install time). Do not treat the tools
+or data here as a current verification mechanism.
+
 Using the SHA512 checksums supplied here, we have verified that all gems match
 at least one third-party mirror or excluding gems that have been yanked.
 


### PR DESCRIPTION
This repository holds the SHA512 checksum lists and one-off comparison scripts produced during the response to the January 2013 rubygems.org compromise. Its contents have been frozen since then and are kept only as a historical record.

Without a notice, the description and the README read as if these tools and data were a current way to verify gems. That is no longer true. Current checksum verification is handled by RubyGems and Bundler themselves through the lockfile `CHECKSUMS` section, the per-version SHA256 in the compact index, and checksum verification at `gem install` time.

This adds a short paragraph at the top of `README.rdoc` marking the repository as a historical archive and pointing to where verification happens today. The existing content is left intact as a record of the 2013 response.
